### PR TITLE
Fix English spelling & grammatical errors on main page.

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -9,7 +9,7 @@ linkTitle = "Moe Editor"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/fox0430/moe">
 		Download <i class="fab fa-github ml-2 "></i>
 	</a>
-	<p class="lead mt-5">A CLI based editor in Nim</p>
+	<p class="lead mt-5">A CLI editor written in Nim</p>
 	{{< blocks/link-down color="white" >}}
 </div>
 {{< /blocks/cover >}}
@@ -22,15 +22,15 @@ linkTitle = "Moe Editor"
 {{< blocks/section color="dark" >}}
 
 {{% blocks/feature icon="fa-lightbulb" title="Written in Nim" url="https://nim-lang.org" %}}
-moe developing in **Nim**. It's a statically typed compiled language. It provides generating native executables, modern type system, memory management, macro system and more.
+moe is developed using **Nim**, a statically typed, compiled language. This provides us with native executables, a modern type system, memory management, a macro system, and more!
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="Vim like modes and keybinds" %}}
-moe is heavily inspired by Vim. It supported vim like keybinds and some modes. Normal mode, Insert mode, Visual mode, Command mode, etc....
+{{% blocks/feature icon="fa-lightbulb" title="Vim-like Modes and Keybinds" %}}
+moe is heavily inspired by Vim. It supports Vim-like keybindings as well as multiple modes (normal, insert, visual, command, etc.).
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-lightbulb" title="GapBuffer" %}}
-moe use GapBuffer for buffer management. It's a data structure suitable for text editors.
+moe uses a GapBuffer for buffer management; it's a data structure well-suited for text editors.
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
@@ -38,15 +38,15 @@ moe use GapBuffer for buffer management. It's a data structure suitable for text
 {{< blocks/section color="dark" >}}
 
 {{% blocks/feature icon="fa-lightbulb" title="Unicode" %}}
-moe support UTF-8 and other encodings. And support full-width characters.
+moe supports UTF-8 and other encodings, including full-width characters.
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-lightbulb" title="Autocomplete" %}}
-You can use a simple autocomplete. You don't need any settings. It suggests words in opened buffers.
+moe has a simple autocomplete, no complicated settings required! moe will suggest words from open buffers.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="Configuration file" %}}
-moe support a configuration file. You can easliy write in TOML.
+{{% blocks/feature icon="fa-lightbulb" title="Configure with TOML" %}}
+moe supports an easy-to-write configuration file using TOML.
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}


### PR DESCRIPTION
I've tried to retain the original meaning and intent of the text as much as possible.

I was randomly browsing the site for your project moe and spotted a few errors I figured I'd fix. I haven't actually built and tested these changes, but it's only some simple text changes so I figure it should be fine!